### PR TITLE
Fixed text overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -191,7 +191,7 @@ button {
 @media screen and (min-width: 968px) {
 	#main {
 		flex-direction: row;
-		height: 100vh;
+		height: 110vh;
 	}
 
 	#search {


### PR DESCRIPTION
This is just a simple fix to some text overlapping, specifically the select dropdown and grading key text overlapping with the footer on desktop.